### PR TITLE
Improve calculation of percentile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>
-      <version>3.0</version>
+      <version>3.6</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/src/main/java/org/nuxeo/tools/gatling/report/RequestStat.java
+++ b/src/main/java/org/nuxeo/tools/gatling/report/RequestStat.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.math3.stat.StatUtils;
 import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
+import org.apache.commons.math3.stat.descriptive.rank.Percentile;
 
 public class RequestStat {
     public static final long MAX_BOXPOINT = 50000;
@@ -103,18 +104,19 @@ public class RequestStat {
 
     public void computeStat(double duration, int maxUsers) {
         double[] times = getDurationAsArray();
-        min = (long) StatUtils.min(times);
-        max = (long) StatUtils.max(times);
+        min = Math.round(StatUtils.min(times));
+        max = Math.round(StatUtils.max(times));
         double sum = 0;
         for (double d : times)
             sum += d;
         avg = sum / times.length;
-        p50 = (long) StatUtils.percentile(times, 50.0);
-        p90 = (long) StatUtils.percentile(times, 90.0);
-        p95 = (long) StatUtils.percentile(times, 95.0);
-        p99 = (long) StatUtils.percentile(times, 99.0);
+        Percentile percentile = new Percentile().withEstimationType(Percentile.EstimationType.R_7);
+        p50 = Math.round(percentile.evaluate(times, 50.0));
+        p90 = Math.round(percentile.evaluate(times, 90.0));
+        p95 = Math.round(percentile.evaluate(times, 95.0));
+        p99 = Math.round(percentile.evaluate(times, 99.0));
         StandardDeviation stdDev = new StandardDeviation();
-        stddev = (long) stdDev.evaluate(times, avg);
+        stddev = Math.round(stdDev.evaluate(times, avg));
         this.duration = duration;
         this.maxUsers = maxUsers;
         rps = (count - errorCount) / duration;


### PR DESCRIPTION
 - Percentile algorithm set to 'R-7' which is default Gatling algorithm;
 - Using Math.round to get calculations more accurate;
 - Updated 'commons-math3' to version '3.6';